### PR TITLE
Accepting nodes with variadic arguments

### DIFF
--- a/glow.go
+++ b/glow.go
@@ -32,8 +32,14 @@ func NewNode(fn interface{}, name string, argNames ...string) *Node {
 	argNames = append([]string{"globals"}, argNames...)
 
 	for i, argName := range argNames {
-		node.args = append(node.args,
-			Argument{name: argName, Type: node.ft.In(i)})
+		var arg Argument
+		if node.ft.IsVariadic() && i >= node.ft.NumIn()-1 {
+			lastArg := node.ft.In(node.ft.NumIn() - 1)
+			arg = Argument{name: argName, Type: lastArg.Elem()}
+		} else {
+			arg = Argument{name: argName, Type: node.ft.In(i)}
+		}
+		node.args = append(node.args, arg)
 	}
 	return node
 }


### PR DESCRIPTION
I added the ability to create nodes with a runtime-defined number of inputs or outputs (fan-in / fan-out) of the same type. This is implemented by using nodes with variadic arguments.

Also, I refactored the way arguments are stored in a Node. I think it is cleaner to store a single slice of structs than keeping in sync several slices.